### PR TITLE
fix: display correct subtotal in express checkout

### DIFF
--- a/app/components/express-checkout-sidebar/express-checkout-sidebar.tsx
+++ b/app/components/express-checkout-sidebar/express-checkout-sidebar.tsx
@@ -96,7 +96,7 @@ const ExpressCheckoutSidebar: FC<ExpressCheckoutSidebarProps> = ({ isOpen, onClo
                 <hr className="my-3"/>
                 <div className="flex justify-between font-bold text-gray-700 mt-2">
                     <p>Subtotal</p>
-                    <p>{orderTotal} ₴</p>
+                    <p>{orderTotal.toFixed(2)} ₴</p>
                 </div>
                 <button
                     onClick={handleSendClick}

--- a/app/components/shopping-cart-sidebar/shopping-cart-sidebar.tsx
+++ b/app/components/shopping-cart-sidebar/shopping-cart-sidebar.tsx
@@ -138,9 +138,9 @@ export default function ShoppingCartSidebar({
         </div>
       </div>
       <ExpressCheckoutSidebar
-        isOpen={isExpressCheckoutOpen}
-        onClose={() => setIsExpressCheckoutOpen(false)}
-        orderTotal={params.order.finalPrice}
+          isOpen={isExpressCheckoutOpen}
+          onClose={() => setIsExpressCheckoutOpen(false)}
+          orderTotal={totalCost}
       />
     </>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the presentation of the order total in the Express Checkout Sidebar, ensuring it consistently displays two decimal places.
	- Updated the calculation of the order total in the Shopping Cart Sidebar to reflect the dynamic total cost based on current cart items.

- **Bug Fixes**
	- Improved accuracy of the order total displayed during checkout by using a dynamically calculated value instead of a static one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->